### PR TITLE
Fix compatibility with Sphinx 4 and 5.0b1.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,13 +14,15 @@ on:
 jobs:
   test:
     strategy:
+      # We want to see all failures:
+      fail-fast: false
       matrix:
         py:
           - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
-          - "pypy3"
+          - "pypy-3.7"
         os:
           - "ubuntu-latest"
           - "windows-latest"
@@ -37,7 +39,7 @@ jobs:
             architecture: x86
           # PyPy3 on Windows doesn't seem to work
           - os: "windows-latest"
-            py: "pypy3"
+            py: "pypy-3.7"
 
     name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/repoze/sphinx/autointerface.py
+++ b/repoze/sphinx/autointerface.py
@@ -88,7 +88,7 @@ class InterfaceDocumenter(autodoc.ClassDocumenter):
                 self.add_line(u'', '<autointerface>')
                 self.indent += self.content_indent
                 sourcename = u'docstring of %s.%s' % (self.fullname, name)
-                docstrings = [prepare_docstring(doc, None)]
+                docstrings = [prepare_docstring(doc)]
                 for i, line in enumerate(self.process_doc(docstrings)):
                     self.add_line(line, sourcename, i)
                 self.add_line(u'', '<autointerface>')

--- a/repoze/sphinx/tests/util.py
+++ b/repoze/sphinx/tests/util.py
@@ -7,8 +7,6 @@ from io import StringIO
 
 from sphinx import application
 from sphinx.builders.latex import LaTeXBuilder
-from sphinx.theming import Theme
-from sphinx.ext.autodoc import AutoDirective
 from sphinx.pycode import ModuleAnalyzer
 
 from docutils import nodes
@@ -98,8 +96,6 @@ class TestApp(application.Sphinx):
 
     def cleanup(self, doctrees=False):
         shutil.rmtree(self.__tempdir)
-        Theme.themes.clear()
-        AutoDirective._registry.clear()
         ModuleAnalyzer.cache.clear()
         LaTeXBuilder.usepackages = []
         sys.path[:] = self._saved_path

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_require = [
 setup(
     name="repoze.sphinx.autointerface",
     version="0.8.1.dev0",
-    description="Sphinx extension: auto-generates API docs " "from Zope interfaces",
+    description="Sphinx extension: auto-generates API docs from Zope interfaces",
     long_description=README + "\n\n" + CHANGES,
     long_description_content_type='text/x-rst',
     classifiers=[
@@ -62,7 +62,7 @@ setup(
     tests_require=tests_require,
     install_requires=[
         "zope.interface",
-        "Sphinx>=1.0",
+        "Sphinx >= 4.0",
         "setuptools",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py36,py37,py38,py39,pypy3
 
 [testenv]
+usedevelop = true
 commands =
     zope-testrunner --test-path={toxinidir}
 deps =


### PR DESCRIPTION
Hi @stevepiercy, this PR adds up on the changes you made to `repoze.sphinx.autointerface`. Locally the tests run with Sphinx 4, 4.5 and 5.0b1.

Spoiler: I am not sure if it is right what I did, I just made the things necessary to get the tests running again.

Could you please consider this PR to make some progress for this package.